### PR TITLE
remove jest from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "get-port": "^4.2.0",
     "globby": "^9.1.0",
     "husky": "^1.3.1",
-    "jest": "^24.5.0",
     "lerna": "2.9.1",
     "lerna-changelog": "~0.8.2",
     "lint-staged": "^8.0.4",
@@ -51,5 +50,8 @@
     "yarn.lock": [
       "git rm --cached"
     ]
+  },
+  "dependencies": {
+    "cross-env": "^5.2.0"
   }
 }


### PR DESCRIPTION
when jest is manually defined in package.json, CRA will complain that the jest dependency is not fulfilled as it asks for another version

removing jest from package.json solves this.